### PR TITLE
updated version of ui-select reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-schema-form": ">= 0.8.0",
     "angular-strap": ">= 2.2.2",
     "bootstrap": "^3.2.0",
-    "ui-select": "^0.11.0"
+    "ui-select": "^0.12.0"
   },
   "main": "angular-schema-form-dynamic-select.js",
   "repository": {


### PR DESCRIPTION
Updated version to match the bower config file. Older versions of ui-select ran a post-install script that would run  "bower install", which fails if your project doesn't use bower.
