### PR TITLE
Added placement option to the strapselect html templates

### DIFF
--- a/src/strapmultiselect.html
+++ b/src/strapmultiselect.html
@@ -6,7 +6,9 @@
         <button type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
                 data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
                 data-html="1"
-                data-multiple="1"  data-multiple="1" data-max-length="{{form.options.inlineMaxLength}}"
+                data-multiple="1"
+				data-placement="{{form.options.placement || 'bottom-left'}}"
+				data-max-length="{{form.options.inlineMaxLength}}"
                 data-max-length-html="{{form.options.inlineMaxLengthHtml}}"
                 bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
                 bs-select>

--- a/src/strapselect.html
+++ b/src/strapselect.html
@@ -7,6 +7,7 @@
                 type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
                 data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
                 data-html="1" data-multiple="1" data-max-length="{{form.options.inlineMaxLength}}"
+				data-placement="{{form.options.placement || 'bottom-left'}}"
                 data-max-length-html="{{form.options.inlineMaxLengthHtml}}"
                 bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
                 bs-select>
@@ -15,6 +16,7 @@
                 type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
                 data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
                 data-html="1"
+				data-placement="{{form.options.placement || 'bottom-left'}}"
                 bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
                 bs-select>
         </button>


### PR DESCRIPTION
In a recent project I used angular-schema-form-dynamic-select but I needed to set the placement of the select box. Strapselect supports a placement attribute (http://mgcrea.github.io/angular-strap/#/selects-usage) so I added a "placement" option which defaults to 'bottom-left' if no placement option is provided.

The screenshots below show placement top, right and bottom-left.

![strapselect_placement](https://cloud.githubusercontent.com/assets/3464839/13325221/dd8ae192-dbd8-11e5-9130-53f92df2235a.png)

Please let me know if you want me to add examples to the app.js.
I have just committed the src files, I assume you don't need the gulp compiled files.
